### PR TITLE
Add configuration alias for config method

### DIFF
--- a/lib/goodmail/configuration.rb
+++ b/lib/goodmail/configuration.rb
@@ -39,6 +39,7 @@ module Goodmail
       @config = DEFAULT_CONFIG.dup unless defined?(@config) && @config
       @config
     end
+    alias_method :configuration, :config
 
     # Resets the configuration back to the default values.
     # Primarily useful for testing environments.

--- a/lib/goodmail/version.rb
+++ b/lib/goodmail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Goodmail
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
## Summary
- Add `configuration` as an alias for `config` method in the Configuration module
- Conventional Rails gems typically expose `.configuration` (e.g., Devise, Omniauth), so this improves API consistency

## Test plan
- [x] Verified alias works: `Goodmail.configuration` now returns the same as `Goodmail.config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)